### PR TITLE
chore: rename to_rdflib to convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ The default response formats are JSON for `SELECT` and `ASK` queries and Turtle 
 - any other string; the supplied value will be passed as MIME Type to the `Accept` header.
 
 
-If the `to_rdflib` parameter is set to `True`, `SPARQLWrapper.query` returns
+If the `convert` parameter is set to `True`, `SPARQLWrapper.query` returns
 
-- an `Iterator` of Python dictionaries with dict-values cast to RDFLib objects for `SELECT` and `ASK` queries
+- an `Iterator` of Python dictionaries with dict-values cast to RDFLib objects for `SELECT` queries
+- a Python `bool` for `ASK` queries
 - an `rdflib.Graph` instance for `CONSTRUCT` and `DESCRIBE` queries.
 
-Note that only JSON is supported as a response format for `to_rdflib` conversions on `SELECT` and `ASK` query results.
+Note that only JSON is supported as a response format for `convert` conversions on `SELECT` and `ASK` query results.
 
 
 #### Client Sharing and Configuration

--- a/src/sparqlx/wrappers.py
+++ b/src/sparqlx/wrappers.py
@@ -14,7 +14,6 @@ import warnings
 
 import httpx
 from rdflib import Graph
-
 from sparqlx.utils.types import _TResponseFormat, _TSPARQLBinding
 from sparqlx.utils.utils import QueryParameters, get_query_parameters
 
@@ -111,7 +110,7 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
     def query(
         self,
         query: str,
-        to_rdflib: TLiteral[True],
+        convert: TLiteral[True],
         response_format: _TResponseFormat | str | None = None,
     ) -> Iterator[_TSPARQLBinding] | Graph: ...
 
@@ -119,18 +118,18 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
     def query(
         self,
         query: str,
-        to_rdflib: TLiteral[False] = False,
+        convert: TLiteral[False] = False,
         response_format: _TResponseFormat | str | None = None,
     ) -> httpx.Response: ...
 
     def query(
         self,
         query: str,
-        to_rdflib: bool = False,
+        convert: bool = False,
         response_format: _TResponseFormat | str | None = None,
     ) -> httpx.Response | Iterator[_TSPARQLBinding] | Graph:
         query_parameters: QueryParameters = get_query_parameters(
-            query=query, to_rdflib=to_rdflib, response_format=response_format
+            query=query, convert=convert, response_format=response_format
         )
 
         with self._managed_client() as client:
@@ -141,7 +140,7 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
             )
             response.raise_for_status()
 
-        if to_rdflib:
+        if convert:
             return query_parameters.rdflib_converter(response)
         return response
 
@@ -149,7 +148,7 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
     async def aquery(
         self,
         query: str,
-        to_rdflib: TLiteral[True],
+        convert: TLiteral[True],
         response_format: _TResponseFormat | str | None = None,
     ) -> Iterator[_TSPARQLBinding] | Graph: ...
 
@@ -157,18 +156,18 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
     async def aquery(
         self,
         query: str,
-        to_rdflib: TLiteral[False] = False,
+        convert: TLiteral[False] = False,
         response_format: _TResponseFormat | str | None = None,
     ) -> httpx.Response: ...
 
     async def aquery(
         self,
         query: str,
-        to_rdflib: bool = False,
+        convert: bool = False,
         response_format: _TResponseFormat | str | None = None,
     ) -> httpx.Response | Iterator[_TSPARQLBinding] | Graph:
         query_parameters: QueryParameters = get_query_parameters(
-            query=query, to_rdflib=to_rdflib, response_format=response_format
+            query=query, convert=convert, response_format=response_format
         )
 
         async with self._managed_aclient() as aclient:
@@ -179,7 +178,7 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
             )
             response.raise_for_status()
 
-        if to_rdflib:
+        if convert:
             return query_parameters.rdflib_converter(response)
         return response
 
@@ -249,7 +248,7 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
     def queries(
         self,
         *queries: str,
-        to_rdflib: TLiteral[True],
+        convert: TLiteral[True],
         response_format: _TResponseFormat | str | None = None,
     ) -> Iterator[Iterator[_TSPARQLBinding]] | Iterator[Graph]: ...
 
@@ -257,14 +256,14 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
     def queries(
         self,
         *queries: str,
-        to_rdflib: TLiteral[False] = False,
+        convert: TLiteral[False] = False,
         response_format: _TResponseFormat | str | None = None,
     ) -> Iterator[httpx.Response]: ...
 
     def queries(
         self,
         *queries: str,
-        to_rdflib: bool = False,
+        convert: bool = False,
         response_format: _TResponseFormat | str | None = None,
     ) -> (
         Iterator[Iterator[_TSPARQLBinding]] | Iterator[httpx.Response] | Iterator[Graph]
@@ -279,7 +278,7 @@ class _SPARQLQueryWrapper(_SPARQLOperationWrapper):
                     tg.create_task(
                         query_component.aquery(
                             query=query,
-                            to_rdflib=to_rdflib,
+                            convert=convert,
                             response_format=response_format,
                         )
                     )

--- a/tests/test_sparqlwrapper/test_client_sharing.py
+++ b/tests/test_sparqlwrapper/test_client_sharing.py
@@ -1,8 +1,6 @@
 """Pytest entry point for SPARQLWrapper httpx client sharing."""
 
 import httpx
-import pytest
-
 from sparqlx import SPARQLWrapper
 
 
@@ -45,6 +43,18 @@ def test_shared_client():
 
     assert all(
         not _client.is_closed
+        for _client in [
+            sparqlwrapper_1.client,
+            sparqlwrapper_1._client,
+            sparqlwrapper_2.client,
+            sparqlwrapper_2._client,
+        ]
+    )
+
+    client.close()
+
+    assert all(
+        _client.is_closed
         for _client in [
             sparqlwrapper_1.client,
             sparqlwrapper_1._client,

--- a/tests/test_sparqlwrapper/test_sparqlwrapper_query.py
+++ b/tests/test_sparqlwrapper/test_sparqlwrapper_query.py
@@ -4,7 +4,7 @@ from sparqlx import SPARQLWrapper
 
 
 def test_sparqlwrapper_query(fuseki_service):
-    endpoint = fuseki_service
+    endpoint: str = fuseki_service
     sparqlwrapper = SPARQLWrapper(endpoint=endpoint)
 
     query = """
@@ -17,5 +17,5 @@ def test_sparqlwrapper_query(fuseki_service):
     }
     """
 
-    result = sparqlwrapper.query(query, to_rdflib=True)
+    result = sparqlwrapper.query(query, convert=True)
     assert list(result) == [{"x": 1, "y": 2}, {"x": 3, "y": 4}]


### PR DESCRIPTION
`to_rdflib` does not make sense for ASK queries and is generally a bit imprecise. `convert` seems a good naming choice for the parameter as it is more generic.