### PR TITLE
test: fix incorrect union type in assert_type

### DIFF
--- a/tests/test_sparqlwrapper/test_static_types/test_query_types.yml
+++ b/tests/test_sparqlwrapper/test_static_types/test_query_types.yml
@@ -16,7 +16,7 @@
     result1 = sparqlwrapper.query(query, convert=True)
     result2 = sparqlwrapper.query(SelectQuery(query), convert=True)
 
-    assert_type(result1, list[SPARQLResultBinding] | bool | Graph) | Graph | bool
+    assert_type(result1, list[SPARQLResultBinding] | bool | Graph)
     assert_type(result2, list[SPARQLResultBinding])
 
 
@@ -37,7 +37,7 @@
     result1 = sparqlwrapper.query(query, convert=True)
     result2 = sparqlwrapper.query(AskQuery(query), convert=True)
 
-    assert_type(result1, list[SPARQLResultBinding] | bool | Graph) | Graph | bool
+    assert_type(result1, list[SPARQLResultBinding] | bool | Graph)
     assert_type(result2, bool)
 
 
@@ -59,7 +59,7 @@
     result1 = sparqlwrapper.query(query, convert=True)
     result2 = sparqlwrapper.query(ConstructQuery(query), convert=True)
 
-    assert_type(result1, list[SPARQLResultBinding] | bool | Graph) | Graph | bool
+    assert_type(result1, list[SPARQLResultBinding] | bool | Graph)
     assert_type(result2, Graph)
 
 
@@ -81,5 +81,5 @@
     result1 = sparqlwrapper.query(query, convert=True)
     result2 = sparqlwrapper.query(DescribeQuery(query), convert=True)
 
-    assert_type(result1, list[SPARQLResultBinding] | bool | Graph) | Graph | bool
+    assert_type(result1, list[SPARQLResultBinding] | bool | Graph)
     assert_type(result2, Graph)


### PR DESCRIPTION
The change removes a superfluous/incorrect union declaration from assert_type calls in static typing tests.

Spotted by @dev-dsp. Thanks!

Closes #80.