### PR TITLE
fix: propagate exceptions in ClientManager.context/.acontext

### DIFF
--- a/src/sparqlx/utils/client_manager.py
+++ b/src/sparqlx/utils/client_manager.py
@@ -44,8 +44,8 @@ class ClientManager:
         finally:
             if self._client is None:
                 client.close()
-                return
-            self._open_client_warning(client)
+            else:
+                self._open_client_warning(client)
 
     @asynccontextmanager
     async def acontext(self) -> AsyncIterator[httpx.AsyncClient]:
@@ -56,8 +56,8 @@ class ClientManager:
         finally:
             if self._aclient is None:
                 await aclient.aclose()
-                return
-            self._open_client_warning(aclient)
+            else:
+                self._open_client_warning(aclient)
 
     @staticmethod
     def _open_client_warning(client: httpx.Client | httpx.AsyncClient) -> None:


### PR DESCRIPTION
Raising `StopIteration` from a `finally` clause in a `contextlib.contextmanager` suppresses any Exceptions that occur in the `with` block. The most serious consquence of this bug in `sparqlx` is that `raise_for_status` in managed `httpx` clients gets suppressed.

To understand the contextlib.contextmanager behavior, one needs to be aware of the following:

- returning from a generator raises `StopIteration`
- returning True from `__exit__` suppresses Exceptions that occur in the lexical context block; this behavior is intentional and documented, see [Context Managers](https://typing.python.org/en/latest/spec/exceptions.html#context-managers) in the Exceptions Docs.
- `contextlib.contextmanager` needs to suppress `StopIteration` unless it is raised in the `with` block, see [contextlib.py, L163](https://github.com/python/cpython/blob/5b5263648f2404b22f9a596c67350c2e602df52b/Lib/contextlib.py#L163).

Since the `finally` clause in the generator-based context manager abstraction of `contextlib.contextmanager` represents the exit mechanism of a context manager, `StopIteration` gets raised in `__exit__` , which is a different case than handling `StopIteration` in `__exit__` when it was raised in `__enter__`.

Note that `StopIteration` is raised in `sparqlx.utils.ClientManager` only for managed clients. This is also the reason, why `httpx.Client.raise_for_status` correctly propagates with user-provided clients!

Closes #94.