### PR TITLE
fix: always raise for status if convert=True

### DIFF
--- a/src/sparqlx/sparqlwrapper.py
+++ b/src/sparqlx/sparqlwrapper.py
@@ -227,7 +227,7 @@ class SPARQLWrapper(AbstractContextManager, AbstractAsyncContextManager):
                 params=params.params,
             )
 
-            if raise_for_status:
+            if convert or raise_for_status:
                 response.raise_for_status()
 
         return response_handler(response=response)
@@ -346,7 +346,7 @@ class SPARQLWrapper(AbstractContextManager, AbstractAsyncContextManager):
                 params=params.params,
             )
 
-            if raise_for_status:
+            if convert or raise_for_status:
                 response.raise_for_status()
 
         return response_handler(response=response)


### PR DESCRIPTION
The change makes it so that `httpx.Response.raise_for_status` is always called if `convert=True`; currently, if `convert=True` and `raise_for_status=False`, non-2xx status responses are passed to the converter logic, which likely raises a `json.DecodeError`.

Closes #119.